### PR TITLE
Adds a few more settings to the vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -9,6 +9,9 @@
 set number
 set mouse=a
 set wildmenu
+set incsearch
+set hlsearch
+set showcmd
 syn on
 
 "let g:molokai_original = 1


### PR DESCRIPTION
 - `incsearch`: While typing a search command, show where the pattern, as it was typed so far, matches.
 - `hlsearch`: When there is a previous search pattern, highlight all its matches.
 - `showcmd`: Show (partial) command in the last line of the screen.